### PR TITLE
Add 3-minute expiration option

### DIFF
--- a/index.php
+++ b/index.php
@@ -7042,6 +7042,7 @@ plt.show()</code></pre>
                   <label class="block text-sm font-medium mb-1">Expiration:</label>
                   <select name="expire" class="w-full p-2 rounded border dark:bg-gray-700 dark:border-gray-600">
                     <option value="never">Never</option>
+                    <option value="180">3 minutes</option>
                     <option value="600">10 minutes</option>
                     <option value="3600">1 hour</option>
                     <option value="86400">1 day</option>


### PR DESCRIPTION
## Summary
- add a 3-minute (180 second) expiration option right after "Never"

## Testing
- `php -l index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68588d217d9c8321be974f76edb93dd2