### PR TITLE
Improve missing paste handling

### DIFF
--- a/index.php
+++ b/index.php
@@ -1521,6 +1521,12 @@ if __name__ == "__main__":
     }
   }
 
+  // Show message if requested paste does not exist
+  if (isset($_GET['id']) && !$paste) {
+    include 'missing_paste_message.php';
+    exit;
+  }
+
   // Get user's pastes for dashboard
   $user_pastes = [];
   $favorite_pastes = [];

--- a/missing_paste_message.php
+++ b/missing_paste_message.php
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Paste Not Found</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.tailwindcss.com" rel="stylesheet">
+    <script>tailwind.config = { darkMode: 'class' }</script>
+</head>
+<body class="bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white flex items-center justify-center min-h-screen">
+    <div class="text-center max-w-md p-6 bg-white dark:bg-gray-800 rounded shadow-md">
+        <div class="text-5xl mb-4 text-red-500">⚠️</div>
+        <h1 class="text-2xl font-bold mb-2">Paste Not Found</h1>
+        <p class="text-gray-600 dark:text-gray-400 mb-4">
+            This paste may have expired, been deleted, or never existed.
+        </p>
+        <a href="/" class="inline-flex items-center text-blue-600 dark:text-blue-400 hover:underline">
+            <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+            </svg>
+            Go back to homepage
+        </a>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add missing paste message template
- display the missing paste message when a paste is not found

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68589008d80c8321a2022d3564efdd66