### PR TITLE
Fix header/session warnings in project_export.php

### DIFF
--- a/project_export.php
+++ b/project_export.php
@@ -1,4 +1,3 @@
-
 <?php
 session_start();
 require_once 'database.php';
@@ -137,4 +136,3 @@ function deleteDirectory($dir) {
 
 deleteDirectory($temp_dir);
 exit;
-?>


### PR DESCRIPTION
## Summary
- remove extraneous whitespace before `<?php`
- drop closing PHP tag

## Testing
- `php -l project_export.php` *(fails: php missing)*

------
https://chatgpt.com/codex/tasks/task_e_685893c58a608321868c87011bb30f93