### PR TITLE
Improve header and 404 page

### DIFF
--- a/errors/404.php
+++ b/errors/404.php
@@ -10,12 +10,29 @@ $theme = $_COOKIE['theme'] ?? 'dark';
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
     <script>
-        tailwind.config = {
-            darkMode: 'class'
+        tailwind.config = { darkMode: 'class' };
+        function initTheme() {
+            const stored = localStorage.getItem('theme');
+            if (stored) {
+                document.documentElement.classList.remove('light', 'dark');
+                document.documentElement.classList.add(stored);
+            }
         }
+        function toggleTheme() {
+            const html = document.documentElement;
+            const newTheme = html.classList.contains('dark') ? 'light' : 'dark';
+            html.classList.remove('dark', 'light');
+            html.classList.add(newTheme);
+            localStorage.setItem('theme', newTheme);
+            document.cookie = `theme=${newTheme};path=/`;
+        }
+        document.addEventListener('DOMContentLoaded', initTheme);
     </script>
 </head>
 <body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-white min-h-screen">
+    <button onclick="toggleTheme()" class="absolute top-4 right-4 p-2 bg-blue-600 text-white rounded-full shadow sm:top-6 sm:right-6 hover:bg-blue-700">
+        <i class="fas fa-moon"></i>
+    </button>
     <div class="min-h-screen flex items-center justify-center p-4">
         <div class="max-w-lg mx-auto text-center">
             <div class="mb-8">

--- a/header.php
+++ b/header.php
@@ -18,24 +18,55 @@ $theme = $_COOKIE['theme'] ?? 'dark';
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
     <script>tailwind.config = { darkMode: 'class' };</script>
+    <script>
+        function initTheme() {
+            const stored = localStorage.getItem('theme');
+            if (stored) {
+                document.documentElement.classList.remove('light', 'dark');
+                document.documentElement.classList.add(stored);
+            }
+        }
+
+        function toggleTheme() {
+            const html = document.documentElement;
+            const newTheme = html.classList.contains('dark') ? 'light' : 'dark';
+            html.classList.remove('dark', 'light');
+            html.classList.add(newTheme);
+            localStorage.setItem('theme', newTheme);
+            document.cookie = `theme=${newTheme};path=/`;
+        }
+
+        document.addEventListener('DOMContentLoaded', initTheme);
+    </script>
 </head>
 <body class="bg-white dark:bg-gray-900 text-gray-900 dark:text-white min-h-screen">
 <nav class="bg-blue-600 dark:bg-blue-800 text-white shadow-lg fixed w-full z-10">
     <div class="max-w-7xl mx-auto px-4">
-        <div class="flex justify-between h-16">
-            <div class="flex items-center space-x-6">
-                <a href="/" class="flex items-center space-x-3">
-                    <i class="fas fa-paste text-2xl"></i>
-                    <span class="text-xl font-bold">PasteForge</span>
-                </a>
-                <div class="flex space-x-4">
-                    <a href="/" class="hover:bg-blue-700 px-3 py-2 rounded">Home</a>
-                    <a href="/?page=archive" class="hover:bg-blue-700 px-3 py-2 rounded">Archive</a>
-                    <a href="/?page=projects" class="px-3 py-2 text-sm font-medium text-white hover:text-blue-300 transition">Projects</a>
-                </div>
+        <div class="flex justify-between h-16 items-center">
+            <a href="/" class="flex items-center space-x-3">
+                <i class="fas fa-paste text-2xl"></i>
+                <span class="text-xl font-bold">PasteForge</span>
+            </a>
+
+            <button id="navToggle" class="sm:hidden p-2 focus:outline-none">
+                <i class="fas fa-bars"></i>
+            </button>
+
+            <div id="navMenu" class="hidden sm:flex sm:items-center space-x-4">
+                <a href="/" class="hover:bg-blue-700 px-3 py-2 rounded">Home</a>
+                <a href="/?page=archive" class="hover:bg-blue-700 px-3 py-2 rounded">Archive</a>
+                <a href="/?page=projects" class="px-3 py-2 text-sm font-medium text-white hover:text-blue-300 transition">Projects</a>
+                <button onclick="toggleTheme()" class="p-2 rounded hover:bg-blue-700"><i class="fas fa-moon"></i></button>
             </div>
         </div>
     </div>
 </nav>
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        const btn = document.getElementById('navToggle');
+        const menu = document.getElementById('navMenu');
+        btn.addEventListener('click', () => menu.classList.toggle('hidden'));
+    });
+</script>
 <div class="mt-20">
 


### PR DESCRIPTION
## Summary
- modernize header with responsive menu and theme persistence
- add dark mode toggle on 404 page

## Testing
- `php -l header.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685975a7d5f483218d10a61ff868a452